### PR TITLE
Translate UI to Korean

### DIFF
--- a/imagemacro.py
+++ b/imagemacro.py
@@ -23,52 +23,52 @@ class MacroStep:
 
 class ImageStep(MacroStep):
     def __init__(self):
-        super().__init__("Image")
+        super().__init__("이미지")
         self.path = ""
         self.mode = tk.StringVar(value="until_success")
         self.max_attempts = tk.IntVar(value=1)
         self.fail_action = tk.StringVar(value="stop")
 
     def summary(self) -> str:
-        return f"Image: {self.path or 'unset'}"
+        return f"이미지: {self.path or '미설정'}"
 
     def edit(self, parent: tk.Tk):
         top = tk.Toplevel(parent)
-        top.title("Image step")
+        top.title("이미지 단계")
 
-        tk.Label(top, text="Image path:").grid(row=0, column=0, sticky="w")
+        tk.Label(top, text="이미지 경로:").grid(row=0, column=0, sticky="w")
         path_entry = tk.Entry(top, width=30)
         path_entry.insert(0, self.path)
         path_entry.grid(row=0, column=1)
 
         def browse():
-            file = filedialog.askopenfilename(title="Select image")
+            file = filedialog.askopenfilename(title="이미지 선택")
             if file:
                 path_entry.delete(0, tk.END)
                 path_entry.insert(0, file)
 
-        tk.Button(top, text="Browse", command=browse).grid(row=0, column=2)
+        tk.Button(top, text="찾아보기", command=browse).grid(row=0, column=2)
 
-        tk.Label(top, text="Mode:").grid(row=1, column=0, sticky="w")
+        tk.Label(top, text="모드:").grid(row=1, column=0, sticky="w")
         modes = [
-            ("Until success", "until_success"),
-            ("Max attempts", "max_attempts"),
-            ("On fail branch", "fail_branch"),
+            ("성공할 때까지", "until_success"),
+            ("최대 시도 횟수", "max_attempts"),
+            ("실패 시 분기", "fail_branch"),
         ]
         for i, (label, value) in enumerate(modes):
             tk.Radiobutton(top, text=label, variable=self.mode, value=value).grid(
                 row=1, column=1 + i, sticky="w"
             )
 
-        tk.Label(top, text="Attempts:").grid(row=2, column=0, sticky="w")
+        tk.Label(top, text="시도 횟수:").grid(row=2, column=0, sticky="w")
         attempts_entry = tk.Entry(top, width=5)
         attempts_entry.insert(0, str(self.max_attempts.get()))
         attempts_entry.grid(row=2, column=1, sticky="w")
 
-        tk.Label(top, text="On fail:").grid(row=3, column=0, sticky="w")
+        tk.Label(top, text="실패 시:").grid(row=3, column=0, sticky="w")
         fail_opts = [
-            ("Stop", "stop"),
-            ("Branch", "branch"),
+            ("중지", "stop"),
+            ("분기", "branch"),
         ]
         for i, (label, value) in enumerate(fail_opts):
             tk.Radiobutton(top, text=label, variable=self.fail_action, value=value).grid(
@@ -80,19 +80,19 @@ class ImageStep(MacroStep):
             try:
                 self.max_attempts.set(int(attempts_entry.get()))
             except ValueError:
-                messagebox.showerror("Error", "Attempts must be integer")
+                messagebox.showerror("오류", "시도 횟수는 정수여야 합니다")
                 return
             top.destroy()
 
-        tk.Button(top, text="OK", command=ok).grid(row=4, column=1)
-        tk.Button(top, text="Cancel", command=top.destroy).grid(row=4, column=2)
+        tk.Button(top, text="확인", command=ok).grid(row=4, column=1)
+        tk.Button(top, text="취소", command=top.destroy).grid(row=4, column=2)
         top.grab_set()
         parent.wait_window(top)
 
 
 class MouseStep(MacroStep):
     def __init__(self):
-        super().__init__("Mouse")
+        super().__init__("마우스")
         self.x = tk.IntVar(value=0)
         self.y = tk.IntVar(value=0)
         self.button = tk.StringVar(value="left")
@@ -101,15 +101,18 @@ class MouseStep(MacroStep):
         self.interval = tk.DoubleVar(value=0.1)
 
     def summary(self) -> str:
-        dbl = " double" if self.double.get() else ""
+        btn_names = {"left": "왼쪽", "right": "오른쪽", "middle": "가운데"}
+        act_names = {"click": "클릭", "press": "누르기", "release": "떼기"}
+        dbl = " 더블" if self.double.get() else ""
         return (
-            f"Mouse {self.action.get()}{dbl} {self.button.get()} "
+            f"마우스 {act_names.get(self.action.get(), self.action.get())}{dbl} "
+            f"{btn_names.get(self.button.get(), self.button.get())} "
             f"@({self.x.get()}, {self.y.get()})"
         )
 
     def edit(self, parent: tk.Tk):
         top = tk.Toplevel(parent)
-        top.title("Mouse step")
+        top.title("마우스 단계")
 
         tk.Label(top, text="X:").grid(row=0, column=0, sticky="w")
         x_entry = tk.Entry(top, width=6)
@@ -129,26 +132,28 @@ class MouseStep(MacroStep):
                 y_entry.delete(0, tk.END)
                 y_entry.insert(0, str(pos.y))
             else:
-                messagebox.showinfo("Info", "pyautogui not available")
+                messagebox.showinfo("정보", "pyautogui를 사용할 수 없습니다")
 
         top.bind("<F10>", capture)
 
-        tk.Label(top, text="Button:").grid(row=1, column=0, sticky="w")
-        buttons = ["left", "right", "middle"]
-        button_combo = ttk.Combobox(top, values=buttons, state="readonly")
-        button_combo.set(self.button.get())
+        tk.Label(top, text="버튼:").grid(row=1, column=0, sticky="w")
+        buttons = {"왼쪽": "left", "오른쪽": "right", "가운데": "middle"}
+        button_combo = ttk.Combobox(top, values=list(buttons.keys()), state="readonly")
+        current_button = next(k for k, v in buttons.items() if v == self.button.get())
+        button_combo.set(current_button)
         button_combo.grid(row=1, column=1)
 
-        tk.Label(top, text="Action:").grid(row=1, column=2, sticky="w")
-        actions = ["click", "press", "release"]
-        action_combo = ttk.Combobox(top, values=actions, state="readonly")
-        action_combo.set(self.action.get())
+        tk.Label(top, text="동작:").grid(row=1, column=2, sticky="w")
+        actions = {"클릭": "click", "누르기": "press", "떼기": "release"}
+        action_combo = ttk.Combobox(top, values=list(actions.keys()), state="readonly")
+        current_action = next(k for k, v in actions.items() if v == self.action.get())
+        action_combo.set(current_action)
         action_combo.grid(row=1, column=3)
 
-        double_chk = tk.Checkbutton(top, text="Double", variable=self.double)
+        double_chk = tk.Checkbutton(top, text="더블", variable=self.double)
         double_chk.grid(row=2, column=0, sticky="w")
 
-        tk.Label(top, text="Interval(s):").grid(row=2, column=1, sticky="w")
+        tk.Label(top, text="간격(초):").grid(row=2, column=1, sticky="w")
         interval_entry = tk.Entry(top, width=6)
         interval_entry.insert(0, str(self.interval.get()))
         interval_entry.grid(row=2, column=2)
@@ -159,33 +164,38 @@ class MouseStep(MacroStep):
                 self.y.set(int(y_entry.get()))
                 self.interval.set(float(interval_entry.get()))
             except ValueError:
-                messagebox.showerror("Error", "Invalid numeric value")
+                messagebox.showerror("오류", "잘못된 숫자 값")
                 return
-            self.button.set(button_combo.get())
-            self.action.set(action_combo.get())
+            self.button.set(buttons[button_combo.get()])
+            self.action.set(actions[action_combo.get()])
             top.unbind("<F10>")
             top.destroy()
 
-        tk.Button(top, text="OK", command=ok).grid(row=3, column=1)
-        tk.Button(top, text="Cancel", command=top.destroy).grid(row=3, column=2)
+        tk.Button(top, text="확인", command=ok).grid(row=3, column=1)
+        tk.Button(top, text="취소", command=top.destroy).grid(row=3, column=2)
         top.grab_set()
         parent.wait_window(top)
 
 
 class KeyboardStep(MacroStep):
     def __init__(self):
-        super().__init__("Keyboard")
+        super().__init__("키보드")
         self.key = tk.StringVar(value="")
         self.action = tk.StringVar(value="press_release")
 
     def summary(self) -> str:
-        return f"Keyboard {self.action.get()} {self.key.get()}"
+        act_names = {
+            "press_release": "누르고 떼기",
+            "press": "누르기",
+            "release": "떼기",
+        }
+        return f"키보드 {act_names.get(self.action.get(), self.action.get())} {self.key.get()}"
 
     def edit(self, parent: tk.Tk):
         top = tk.Toplevel(parent)
-        top.title("Keyboard step")
+        top.title("키보드 단계")
 
-        tk.Label(top, text="Key:").grid(row=0, column=0, sticky="w")
+        tk.Label(top, text="키:").grid(row=0, column=0, sticky="w")
         key_entry = tk.Entry(top, width=10)
         key_entry.insert(0, self.key.get())
         key_entry.grid(row=0, column=1)
@@ -204,13 +214,13 @@ class KeyboardStep(MacroStep):
             capturing.set(True)
             top.bind("<Key>", capture_key)
 
-        tk.Button(top, text="Input", command=start_capture).grid(row=0, column=2)
+        tk.Button(top, text="입력", command=start_capture).grid(row=0, column=2)
 
-        tk.Label(top, text="Action:").grid(row=1, column=0, sticky="w")
+        tk.Label(top, text="동작:").grid(row=1, column=0, sticky="w")
         actions = [
-            ("Press+Release", "press_release"),
-            ("Press", "press"),
-            ("Release", "release"),
+            ("누르고 떼기", "press_release"),
+            ("누르기", "press"),
+            ("떼기", "release"),
         ]
         for i, (label, value) in enumerate(actions):
             tk.Radiobutton(top, text=label, variable=self.action, value=value).grid(
@@ -221,25 +231,25 @@ class KeyboardStep(MacroStep):
             self.key.set(key_entry.get())
             top.destroy()
 
-        tk.Button(top, text="OK", command=ok).grid(row=2, column=1)
-        tk.Button(top, text="Cancel", command=top.destroy).grid(row=2, column=2)
+        tk.Button(top, text="확인", command=ok).grid(row=2, column=1)
+        tk.Button(top, text="취소", command=top.destroy).grid(row=2, column=2)
         top.grab_set()
         parent.wait_window(top)
 
 
 class DelayStep(MacroStep):
     def __init__(self):
-        super().__init__("Delay")
+        super().__init__("지연")
         self.duration = tk.DoubleVar(value=1.0)
 
     def summary(self) -> str:
-        return f"Delay {self.duration.get():.3f}s"
+        return f"지연 {self.duration.get():.3f}초"
 
     def edit(self, parent: tk.Tk):
         top = tk.Toplevel(parent)
-        top.title("Delay step")
+        top.title("지연 단계")
 
-        tk.Label(top, text="Seconds:").grid(row=0, column=0, sticky="w")
+        tk.Label(top, text="초:").grid(row=0, column=0, sticky="w")
         entry = tk.Entry(top, width=10)
         entry.insert(0, str(self.duration.get()))
         entry.grid(row=0, column=1)
@@ -248,34 +258,34 @@ class DelayStep(MacroStep):
             try:
                 val = float(entry.get())
             except ValueError:
-                messagebox.showerror("Error", "Invalid number")
+                messagebox.showerror("오류", "잘못된 숫자")
                 return
             if val < 0.001:
-                messagebox.showerror("Error", "Must be >= 0.001")
+                messagebox.showerror("오류", "0.001 이상이어야 합니다")
                 return
             self.duration.set(val)
             top.destroy()
 
-        tk.Button(top, text="OK", command=ok).grid(row=1, column=1)
-        tk.Button(top, text="Cancel", command=top.destroy).grid(row=1, column=2)
+        tk.Button(top, text="확인", command=ok).grid(row=1, column=1)
+        tk.Button(top, text="취소", command=top.destroy).grid(row=1, column=2)
         top.grab_set()
         parent.wait_window(top)
 
 
 class TextStep(MacroStep):
     def __init__(self):
-        super().__init__("Text")
+        super().__init__("텍스트")
         self.text = tk.StringVar(value="")
 
     def summary(self) -> str:
         txt = self.text.get()
-        return f"Text: {txt[:10]}" + ("..." if len(txt) > 10 else "")
+        return f"텍스트: {txt[:10]}" + ("..." if len(txt) > 10 else "")
 
     def edit(self, parent: tk.Tk):
         top = tk.Toplevel(parent)
-        top.title("Text step")
+        top.title("텍스트 단계")
 
-        tk.Label(top, text="Text:").grid(row=0, column=0, sticky="w")
+        tk.Label(top, text="텍스트:").grid(row=0, column=0, sticky="w")
         entry = tk.Entry(top, width=40)
         entry.insert(0, self.text.get())
         entry.grid(row=0, column=1)
@@ -284,25 +294,25 @@ class TextStep(MacroStep):
             self.text.set(entry.get())
             top.destroy()
 
-        tk.Button(top, text="OK", command=ok).grid(row=1, column=1)
-        tk.Button(top, text="Cancel", command=top.destroy).grid(row=1, column=2)
+        tk.Button(top, text="확인", command=ok).grid(row=1, column=1)
+        tk.Button(top, text="취소", command=top.destroy).grid(row=1, column=2)
         top.grab_set()
         parent.wait_window(top)
 
 
 class RepeatStep(MacroStep):
     def __init__(self):
-        super().__init__("Repeat")
+        super().__init__("반복")
         self.count = tk.IntVar(value=2)
 
     def summary(self) -> str:
-        return f"Repeat x{self.count.get()}"
+        return f"반복 x{self.count.get()}"
 
     def edit(self, parent: tk.Tk):
         top = tk.Toplevel(parent)
-        top.title("Repeat step")
+        top.title("반복 단계")
 
-        tk.Label(top, text="Count:").grid(row=0, column=0, sticky="w")
+        tk.Label(top, text="횟수:").grid(row=0, column=0, sticky="w")
         entry = tk.Entry(top, width=5)
         entry.insert(0, str(self.count.get()))
         entry.grid(row=0, column=1)
@@ -311,13 +321,13 @@ class RepeatStep(MacroStep):
             try:
                 val = int(entry.get())
             except ValueError:
-                messagebox.showerror("Error", "Invalid number")
+                messagebox.showerror("오류", "잘못된 숫자")
                 return
             self.count.set(val)
             top.destroy()
 
-        tk.Button(top, text="OK", command=ok).grid(row=1, column=1)
-        tk.Button(top, text="Cancel", command=top.destroy).grid(row=1, column=2)
+        tk.Button(top, text="확인", command=ok).grid(row=1, column=1)
+        tk.Button(top, text="취소", command=top.destroy).grid(row=1, column=2)
         top.grab_set()
         parent.wait_window(top)
 
@@ -330,12 +340,12 @@ class MacroApp:
         left = tk.Frame(root)
         left.pack(side=tk.LEFT, fill=tk.Y)
 
-        tk.Button(left, text="Add Image", command=self.add_image).pack(fill=tk.X)
-        tk.Button(left, text="Add Mouse", command=self.add_mouse).pack(fill=tk.X)
-        tk.Button(left, text="Add Keyboard", command=self.add_keyboard).pack(fill=tk.X)
-        tk.Button(left, text="Add Delay", command=self.add_delay).pack(fill=tk.X)
-        tk.Button(left, text="Add Text", command=self.add_text).pack(fill=tk.X)
-        tk.Button(left, text="Add Repeat", command=self.add_repeat).pack(fill=tk.X)
+        tk.Button(left, text="이미지 추가", command=self.add_image).pack(fill=tk.X)
+        tk.Button(left, text="마우스 추가", command=self.add_mouse).pack(fill=tk.X)
+        tk.Button(left, text="키보드 추가", command=self.add_keyboard).pack(fill=tk.X)
+        tk.Button(left, text="지연 추가", command=self.add_delay).pack(fill=tk.X)
+        tk.Button(left, text="텍스트 추가", command=self.add_text).pack(fill=tk.X)
+        tk.Button(left, text="반복 추가", command=self.add_repeat).pack(fill=tk.X)
 
         self.listbox = tk.Listbox(root)
         self.listbox.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True)
@@ -395,7 +405,7 @@ class MacroApp:
 
 def main():
     root = tk.Tk()
-    root.title("Image Macro Builder")
+    root.title("이미지 매크로 빌더")
     app = MacroApp(root)
     root.mainloop()
 


### PR DESCRIPTION
## Summary
- Localize macro builder UI by translating all step dialogs, buttons, and messages into Korean.
- Update main window title and controls to display Korean labels.

## Testing
- `python -m py_compile imagemacro.py`


------
https://chatgpt.com/codex/tasks/task_e_68b184d9fc488332980c912b58b40afe