### PR TITLE
Enhance macro builder UI and step controls

### DIFF
--- a/imagemacro.py
+++ b/imagemacro.py
@@ -30,16 +30,28 @@ class ImageStep(MacroStep):
         self.fail_action = tk.StringVar(value="stop")
 
     def summary(self) -> str:
-        return f"이미지: {self.path or '미설정'}"
+        mode = self.mode.get()
+        if mode == "until_success":
+            cond = "성공할 때까지"
+        elif mode == "max_attempts":
+            fail = "중지" if self.fail_action.get() == "stop" else "분기"
+            cond = f"최대 {self.max_attempts.get()}회 실패 시 {fail}"
+        elif mode == "fail_branch":
+            cond = "실패 시 분기"
+        else:
+            cond = ""
+        prefix = f"[{cond}] " if cond else ""
+        return f"{prefix}이미지: {self.path or '미설정'}"
 
     def edit(self, parent: tk.Tk):
         top = tk.Toplevel(parent)
         top.title("이미지 단계")
+        top.geometry("400x200")
 
-        tk.Label(top, text="이미지 경로:").grid(row=0, column=0, sticky="w")
+        tk.Label(top, text="이미지 경로:").grid(row=0, column=0, sticky="w", padx=5, pady=5)
         path_entry = tk.Entry(top, width=30)
         path_entry.insert(0, self.path)
-        path_entry.grid(row=0, column=1)
+        path_entry.grid(row=0, column=1, padx=5, pady=5)
 
         def browse():
             file = filedialog.askopenfilename(title="이미지 선택")
@@ -47,9 +59,9 @@ class ImageStep(MacroStep):
                 path_entry.delete(0, tk.END)
                 path_entry.insert(0, file)
 
-        tk.Button(top, text="찾아보기", command=browse).grid(row=0, column=2)
+        tk.Button(top, text="찾아보기", command=browse).grid(row=0, column=2, padx=5, pady=5)
 
-        tk.Label(top, text="모드:").grid(row=1, column=0, sticky="w")
+        tk.Label(top, text="모드:").grid(row=1, column=0, sticky="w", padx=5, pady=5)
         modes = [
             ("성공할 때까지", "until_success"),
             ("최대 시도 횟수", "max_attempts"),
@@ -57,22 +69,22 @@ class ImageStep(MacroStep):
         ]
         for i, (label, value) in enumerate(modes):
             tk.Radiobutton(top, text=label, variable=self.mode, value=value).grid(
-                row=1, column=1 + i, sticky="w"
+                row=1, column=1 + i, sticky="w", padx=5, pady=5
             )
 
-        tk.Label(top, text="시도 횟수:").grid(row=2, column=0, sticky="w")
+        tk.Label(top, text="시도 횟수:").grid(row=2, column=0, sticky="w", padx=5, pady=5)
         attempts_entry = tk.Entry(top, width=5)
         attempts_entry.insert(0, str(self.max_attempts.get()))
-        attempts_entry.grid(row=2, column=1, sticky="w")
+        attempts_entry.grid(row=2, column=1, sticky="w", padx=5, pady=5)
 
-        tk.Label(top, text="실패 시:").grid(row=3, column=0, sticky="w")
+        tk.Label(top, text="실패 시:").grid(row=3, column=0, sticky="w", padx=5, pady=5)
         fail_opts = [
             ("중지", "stop"),
             ("분기", "branch"),
         ]
         for i, (label, value) in enumerate(fail_opts):
             tk.Radiobutton(top, text=label, variable=self.fail_action, value=value).grid(
-                row=3, column=1 + i, sticky="w"
+                row=3, column=1 + i, sticky="w", padx=5, pady=5
             )
 
         def ok():
@@ -84,8 +96,8 @@ class ImageStep(MacroStep):
                 return
             top.destroy()
 
-        tk.Button(top, text="확인", command=ok).grid(row=4, column=1)
-        tk.Button(top, text="취소", command=top.destroy).grid(row=4, column=2)
+        tk.Button(top, text="확인", command=ok).grid(row=4, column=1, padx=5, pady=5)
+        tk.Button(top, text="취소", command=top.destroy).grid(row=4, column=2, padx=5, pady=5)
         top.grab_set()
         parent.wait_window(top)
 
@@ -113,16 +125,17 @@ class MouseStep(MacroStep):
     def edit(self, parent: tk.Tk):
         top = tk.Toplevel(parent)
         top.title("마우스 단계")
+        top.geometry("400x200")
 
-        tk.Label(top, text="X:").grid(row=0, column=0, sticky="w")
+        tk.Label(top, text="X:").grid(row=0, column=0, sticky="w", padx=5, pady=5)
         x_entry = tk.Entry(top, width=6)
         x_entry.insert(0, str(self.x.get()))
-        x_entry.grid(row=0, column=1)
+        x_entry.grid(row=0, column=1, padx=5, pady=5)
 
-        tk.Label(top, text="Y:").grid(row=0, column=2, sticky="w")
+        tk.Label(top, text="Y:").grid(row=0, column=2, sticky="w", padx=5, pady=5)
         y_entry = tk.Entry(top, width=6)
         y_entry.insert(0, str(self.y.get()))
-        y_entry.grid(row=0, column=3)
+        y_entry.grid(row=0, column=3, padx=5, pady=5)
 
         def capture(event=None):
             if pyautogui:
@@ -136,27 +149,27 @@ class MouseStep(MacroStep):
 
         top.bind("<F10>", capture)
 
-        tk.Label(top, text="버튼:").grid(row=1, column=0, sticky="w")
+        tk.Label(top, text="버튼:").grid(row=1, column=0, sticky="w", padx=5, pady=5)
         buttons = {"왼쪽": "left", "오른쪽": "right", "가운데": "middle"}
         button_combo = ttk.Combobox(top, values=list(buttons.keys()), state="readonly")
         current_button = next(k for k, v in buttons.items() if v == self.button.get())
         button_combo.set(current_button)
-        button_combo.grid(row=1, column=1)
+        button_combo.grid(row=1, column=1, padx=5, pady=5)
 
-        tk.Label(top, text="동작:").grid(row=1, column=2, sticky="w")
+        tk.Label(top, text="동작:").grid(row=1, column=2, sticky="w", padx=5, pady=5)
         actions = {"클릭": "click", "누르기": "press", "떼기": "release"}
         action_combo = ttk.Combobox(top, values=list(actions.keys()), state="readonly")
         current_action = next(k for k, v in actions.items() if v == self.action.get())
         action_combo.set(current_action)
-        action_combo.grid(row=1, column=3)
+        action_combo.grid(row=1, column=3, padx=5, pady=5)
 
         double_chk = tk.Checkbutton(top, text="더블", variable=self.double)
-        double_chk.grid(row=2, column=0, sticky="w")
+        double_chk.grid(row=2, column=0, sticky="w", padx=5, pady=5)
 
-        tk.Label(top, text="간격(초):").grid(row=2, column=1, sticky="w")
+        tk.Label(top, text="간격(초):").grid(row=2, column=1, sticky="w", padx=5, pady=5)
         interval_entry = tk.Entry(top, width=6)
         interval_entry.insert(0, str(self.interval.get()))
-        interval_entry.grid(row=2, column=2)
+        interval_entry.grid(row=2, column=2, padx=5, pady=5)
 
         def ok():
             try:
@@ -171,8 +184,8 @@ class MouseStep(MacroStep):
             top.unbind("<F10>")
             top.destroy()
 
-        tk.Button(top, text="확인", command=ok).grid(row=3, column=1)
-        tk.Button(top, text="취소", command=top.destroy).grid(row=3, column=2)
+        tk.Button(top, text="확인", command=ok).grid(row=3, column=1, padx=5, pady=5)
+        tk.Button(top, text="취소", command=top.destroy).grid(row=3, column=2, padx=5, pady=5)
         top.grab_set()
         parent.wait_window(top)
 
@@ -194,11 +207,12 @@ class KeyboardStep(MacroStep):
     def edit(self, parent: tk.Tk):
         top = tk.Toplevel(parent)
         top.title("키보드 단계")
+        top.geometry("400x200")
 
-        tk.Label(top, text="키:").grid(row=0, column=0, sticky="w")
+        tk.Label(top, text="키:").grid(row=0, column=0, sticky="w", padx=5, pady=5)
         key_entry = tk.Entry(top, width=10)
         key_entry.insert(0, self.key.get())
-        key_entry.grid(row=0, column=1)
+        key_entry.grid(row=0, column=1, padx=5, pady=5)
 
         capturing = tk.BooleanVar(value=False)
 
@@ -214,9 +228,9 @@ class KeyboardStep(MacroStep):
             capturing.set(True)
             top.bind("<Key>", capture_key)
 
-        tk.Button(top, text="입력", command=start_capture).grid(row=0, column=2)
+        tk.Button(top, text="입력", command=start_capture).grid(row=0, column=2, padx=5, pady=5)
 
-        tk.Label(top, text="동작:").grid(row=1, column=0, sticky="w")
+        tk.Label(top, text="동작:").grid(row=1, column=0, sticky="w", padx=5, pady=5)
         actions = [
             ("누르고 떼기", "press_release"),
             ("누르기", "press"),
@@ -224,15 +238,15 @@ class KeyboardStep(MacroStep):
         ]
         for i, (label, value) in enumerate(actions):
             tk.Radiobutton(top, text=label, variable=self.action, value=value).grid(
-                row=1, column=1 + i, sticky="w"
+                row=1, column=1 + i, sticky="w", padx=5, pady=5
             )
 
         def ok():
             self.key.set(key_entry.get())
             top.destroy()
 
-        tk.Button(top, text="확인", command=ok).grid(row=2, column=1)
-        tk.Button(top, text="취소", command=top.destroy).grid(row=2, column=2)
+        tk.Button(top, text="확인", command=ok).grid(row=2, column=1, padx=5, pady=5)
+        tk.Button(top, text="취소", command=top.destroy).grid(row=2, column=2, padx=5, pady=5)
         top.grab_set()
         parent.wait_window(top)
 
@@ -248,11 +262,12 @@ class DelayStep(MacroStep):
     def edit(self, parent: tk.Tk):
         top = tk.Toplevel(parent)
         top.title("지연 단계")
+        top.geometry("300x120")
 
-        tk.Label(top, text="초:").grid(row=0, column=0, sticky="w")
+        tk.Label(top, text="초:").grid(row=0, column=0, sticky="w", padx=5, pady=5)
         entry = tk.Entry(top, width=10)
         entry.insert(0, str(self.duration.get()))
-        entry.grid(row=0, column=1)
+        entry.grid(row=0, column=1, padx=5, pady=5)
 
         def ok():
             try:
@@ -266,8 +281,8 @@ class DelayStep(MacroStep):
             self.duration.set(val)
             top.destroy()
 
-        tk.Button(top, text="확인", command=ok).grid(row=1, column=1)
-        tk.Button(top, text="취소", command=top.destroy).grid(row=1, column=2)
+        tk.Button(top, text="확인", command=ok).grid(row=1, column=1, padx=5, pady=5)
+        tk.Button(top, text="취소", command=top.destroy).grid(row=1, column=2, padx=5, pady=5)
         top.grab_set()
         parent.wait_window(top)
 
@@ -284,18 +299,19 @@ class TextStep(MacroStep):
     def edit(self, parent: tk.Tk):
         top = tk.Toplevel(parent)
         top.title("텍스트 단계")
+        top.geometry("400x150")
 
-        tk.Label(top, text="텍스트:").grid(row=0, column=0, sticky="w")
+        tk.Label(top, text="텍스트:").grid(row=0, column=0, sticky="w", padx=5, pady=5)
         entry = tk.Entry(top, width=40)
         entry.insert(0, self.text.get())
-        entry.grid(row=0, column=1)
+        entry.grid(row=0, column=1, padx=5, pady=5)
 
         def ok():
             self.text.set(entry.get())
             top.destroy()
 
-        tk.Button(top, text="확인", command=ok).grid(row=1, column=1)
-        tk.Button(top, text="취소", command=top.destroy).grid(row=1, column=2)
+        tk.Button(top, text="확인", command=ok).grid(row=1, column=1, padx=5, pady=5)
+        tk.Button(top, text="취소", command=top.destroy).grid(row=1, column=2, padx=5, pady=5)
         top.grab_set()
         parent.wait_window(top)
 
@@ -303,19 +319,20 @@ class TextStep(MacroStep):
 class RepeatStep(MacroStep):
     def __init__(self):
         super().__init__("반복")
-        self.count = tk.IntVar(value=2)
+        self.count = tk.IntVar(value=1)
 
     def summary(self) -> str:
-        return f"반복 x{self.count.get()}"
+        return f"반복 {self.count.get()}회"
 
     def edit(self, parent: tk.Tk):
         top = tk.Toplevel(parent)
         top.title("반복 단계")
+        top.geometry("300x120")
 
-        tk.Label(top, text="횟수:").grid(row=0, column=0, sticky="w")
+        tk.Label(top, text="횟수:").grid(row=0, column=0, sticky="w", padx=5, pady=5)
         entry = tk.Entry(top, width=5)
         entry.insert(0, str(self.count.get()))
-        entry.grid(row=0, column=1)
+        entry.grid(row=0, column=1, padx=5, pady=5)
 
         def ok():
             try:
@@ -326,8 +343,8 @@ class RepeatStep(MacroStep):
             self.count.set(val)
             top.destroy()
 
-        tk.Button(top, text="확인", command=ok).grid(row=1, column=1)
-        tk.Button(top, text="취소", command=top.destroy).grid(row=1, column=2)
+        tk.Button(top, text="확인", command=ok).grid(row=1, column=1, padx=5, pady=5)
+        tk.Button(top, text="취소", command=top.destroy).grid(row=1, column=2, padx=5, pady=5)
         top.grab_set()
         parent.wait_window(top)
 
@@ -338,21 +355,23 @@ class MacroApp:
         self.steps: list[MacroStep] = []
 
         left = tk.Frame(root)
-        left.pack(side=tk.LEFT, fill=tk.Y)
+        left.pack(side=tk.LEFT, fill=tk.Y, padx=5, pady=5)
 
-        tk.Button(left, text="이미지 추가", command=self.add_image).pack(fill=tk.X)
-        tk.Button(left, text="마우스 추가", command=self.add_mouse).pack(fill=tk.X)
-        tk.Button(left, text="키보드 추가", command=self.add_keyboard).pack(fill=tk.X)
-        tk.Button(left, text="지연 추가", command=self.add_delay).pack(fill=tk.X)
-        tk.Button(left, text="텍스트 추가", command=self.add_text).pack(fill=tk.X)
-        tk.Button(left, text="반복 추가", command=self.add_repeat).pack(fill=tk.X)
+        tk.Button(left, text="이미지 추가", command=self.add_image).pack(fill=tk.X, pady=2)
+        tk.Button(left, text="마우스 추가", command=self.add_mouse).pack(fill=tk.X, pady=2)
+        tk.Button(left, text="키보드 추가", command=self.add_keyboard).pack(fill=tk.X, pady=2)
+        tk.Button(left, text="지연 추가", command=self.add_delay).pack(fill=tk.X, pady=2)
+        tk.Button(left, text="텍스트 추가", command=self.add_text).pack(fill=tk.X, pady=2)
+        tk.Button(left, text="반복 추가", command=self.add_repeat).pack(fill=tk.X, pady=2)
+        tk.Button(left, text="삭제", command=self.delete_selected).pack(fill=tk.X, pady=2)
 
         self.listbox = tk.Listbox(root)
-        self.listbox.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True)
+        self.listbox.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True, padx=5, pady=5)
 
         self.listbox.bind('<Double-Button-1>', self.edit_selected)
         self.listbox.bind('<ButtonPress-1>', self.start_drag)
         self.listbox.bind('<B1-Motion>', self.on_drag)
+        self.listbox.bind('<Delete>', self.delete_selected)
         self.drag_index = None
 
     def add_step(self, step: MacroStep):
@@ -377,6 +396,14 @@ class MacroApp:
 
     def add_repeat(self):
         self.add_step(RepeatStep())
+
+    def delete_selected(self, event=None):
+        idx = self.listbox.curselection()
+        if not idx:
+            return
+        i = idx[0]
+        del self.steps[i]
+        self.listbox.delete(i)
 
     def edit_selected(self, event=None):
         idx = self.listbox.curselection()
@@ -406,6 +433,7 @@ class MacroApp:
 def main():
     root = tk.Tk()
     root.title("이미지 매크로 빌더")
+    root.geometry("800x600")
     app = MacroApp(root)
     root.mainloop()
 


### PR DESCRIPTION
## Summary
- Display image step conditions in square brackets and widen configuration dialogs with padding
- Allow removing steps via Delete button or key and show repeat counts starting from 1
- Enlarge main window for a roomier interface

## Testing
- `python -m py_compile imagemacro.py`


------
https://chatgpt.com/codex/tasks/task_e_68b189f5c24c8332a13e508ed2a02810