### PR TITLE
Refine macro builder layout with inline editor

### DIFF
--- a/imagemacro.py
+++ b/imagemacro.py
@@ -24,12 +24,16 @@ class MacroStep:
     def summary(self) -> str:
         return self.name
 
-    def edit(self, parent: tk.Tk):
-        """Override in subclasses to configure the step.
-
-        Should return True if the user confirmed the dialog, False otherwise.
-        """
+    def build_editor(self, parent: tk.Widget):
+        """Create editor widgets inside *parent*."""
         raise NotImplementedError
+
+    def apply_editor(self) -> bool:
+        """Apply values from editor widgets.
+
+        Returns True on success, False if validation failed.
+        """
+        return True
 
 
 class ImageStep(MacroStep):
@@ -54,40 +58,25 @@ class ImageStep(MacroStep):
         prefix = f"[{cond}] " if cond else ""
         return f"{prefix}이미지: {self.path or '미설정'}"
 
-    def edit(self, parent: tk.Tk):
-        top = tk.Toplevel(parent)
-        top.title("이미지 단계")
-
-        tk.Label(top, text="이미지 경로:").grid(row=0, column=0, sticky="w", padx=5, pady=5)
-        path_entry = tk.Entry(top, width=30)
-        path_entry.insert(0, self.path)
-        path_entry.grid(row=0, column=1, padx=5, pady=5)
+    def build_editor(self, parent: tk.Widget):
+        tk.Label(parent, text="이미지 경로:").grid(row=0, column=0, sticky="w", padx=5, pady=5)
+        self._path_entry = tk.Entry(parent, width=30)
+        self._path_entry.insert(0, self.path)
+        self._path_entry.grid(row=0, column=1, padx=5, pady=5)
 
         def browse():
             file = filedialog.askopenfilename(title="이미지 선택")
             if file:
-                path_entry.delete(0, tk.END)
-                path_entry.insert(0, file)
+                self._path_entry.delete(0, tk.END)
+                self._path_entry.insert(0, file)
 
-        tk.Button(top, text="찾아보기", command=browse).grid(row=0, column=2, padx=5, pady=5)
-
-        def show_preview(path: str):
-            if not os.path.exists(path):
-                return
-            prev = tk.Toplevel(parent)
-            prev.title("미리보기")
-            img = tk.PhotoImage(file=path)
-            lbl = tk.Label(prev, image=img)
-            lbl.image = img
-            lbl.pack()
+        tk.Button(parent, text="찾아보기", command=browse).grid(row=0, column=2, padx=5, pady=5)
 
         def capture():
             if pyautogui is None:
                 messagebox.showerror("오류", "pyautogui가 필요합니다")
                 return
-            top.withdraw()
-            parent.iconify()
-            parent.update()
+            parent.winfo_toplevel().iconify()
 
             overlay = tk.Toplevel()
             overlay.attributes("-fullscreen", True)
@@ -104,98 +93,73 @@ class ImageStep(MacroStep):
             start = {"x": 0, "y": 0}
             rect = {"id": None}
 
-            def on_right_press(event):
+            def on_press(event):
                 start["x"], start["y"] = event.x, event.y
-                rect["id"] = canvas.create_rectangle(
-                    event.x, event.y, event.x, event.y, outline="red"
-                )
+                rect["id"] = canvas.create_rectangle(event.x, event.y, event.x, event.y, outline="red")
 
-            def on_right_drag(event):
+            def on_drag(event):
                 if rect["id"]:
                     canvas.coords(rect["id"], start["x"], start["y"], event.x, event.y)
 
-            def on_right_release(event):
+            def on_release(event):
                 overlay.destroy()
                 x1 = overlay.winfo_rootx() + start["x"]
                 y1 = overlay.winfo_rooty() + start["y"]
                 x2 = overlay.winfo_rootx() + event.x
                 y2 = overlay.winfo_rooty() + event.y
-                region = (
-                    min(x1, x2),
-                    min(y1, y2),
-                    abs(x2 - x1),
-                    abs(y2 - y1),
-                )
+                region = (min(x1, x2), min(y1, y2), abs(x2 - x1), abs(y2 - y1))
                 img = pyautogui.screenshot(region=region)
                 fd, tmp = tempfile.mkstemp(suffix=".png")
                 os.close(fd)
                 img.save(tmp)
-                path_entry.delete(0, tk.END)
-                path_entry.insert(0, tmp)
-                show_preview(tmp)
-                parent.deiconify()
-                top.deiconify()
+                self._path_entry.delete(0, tk.END)
+                self._path_entry.insert(0, tmp)
+                parent.winfo_toplevel().deiconify()
 
-            def on_left_click(event):
-                overlay.destroy()
-                parent.deiconify()
-                top.deiconify()
-
-            overlay.bind("<ButtonPress-3>", on_right_press)
-            overlay.bind("<B3-Motion>", on_right_drag)
-            overlay.bind("<ButtonRelease-3>", on_right_release)
-            overlay.bind("<ButtonPress-1>", on_left_click)
+            overlay.bind("<ButtonPress-3>", on_press)
+            overlay.bind("<B3-Motion>", on_drag)
+            overlay.bind("<ButtonRelease-3>", on_release)
+            overlay.bind("<ButtonPress-1>", lambda e: (overlay.destroy(), parent.winfo_toplevel().deiconify()))
             overlay.grab_set()
             parent.wait_window(overlay)
 
-        tk.Button(top, text="캡쳐", command=capture).grid(row=0, column=3, padx=5, pady=5)
+        tk.Button(parent, text="캡쳐", command=capture).grid(row=0, column=3, padx=5, pady=5)
 
-        tk.Label(top, text="모드:").grid(row=1, column=0, sticky="w", padx=5, pady=5)
+        tk.Label(parent, text="모드:").grid(row=1, column=0, sticky="w", padx=5, pady=5)
         modes = [
             ("성공할 때까지", "until_success"),
             ("최대 시도 횟수", "max_attempts"),
             ("실패 시 분기", "fail_branch"),
         ]
         for i, (label, value) in enumerate(modes):
-            tk.Radiobutton(top, text=label, variable=self.mode, value=value).grid(
+            tk.Radiobutton(parent, text=label, variable=self.mode, value=value).grid(
                 row=1, column=1 + i, sticky="w", padx=5, pady=5
             )
 
-        tk.Label(top, text="시도 횟수:").grid(row=2, column=0, sticky="w", padx=5, pady=5)
-        attempts_entry = tk.Entry(top, width=5)
-        attempts_entry.insert(0, str(self.max_attempts.get()))
-        attempts_entry.grid(row=2, column=1, sticky="w", padx=5, pady=5)
+        tk.Label(parent, text="시도 횟수:").grid(row=2, column=0, sticky="w", padx=5, pady=5)
+        self._attempts_entry = tk.Entry(parent, width=5)
+        self._attempts_entry.insert(0, str(self.max_attempts.get()))
+        self._attempts_entry.grid(row=2, column=1, sticky="w", padx=5, pady=5)
 
-        tk.Label(top, text="실패 시:").grid(row=3, column=0, sticky="w", padx=5, pady=5)
+        tk.Label(parent, text="실패 시:").grid(row=3, column=0, sticky="w", padx=5, pady=5)
         fail_opts = [
             ("중지", "stop"),
             ("분기", "branch"),
         ]
         for i, (label, value) in enumerate(fail_opts):
-            tk.Radiobutton(top, text=label, variable=self.fail_action, value=value).grid(
+            tk.Radiobutton(parent, text=label, variable=self.fail_action, value=value).grid(
                 row=3, column=1 + i, sticky="w", padx=5, pady=5
             )
 
-        result = {"ok": False}
+    def apply_editor(self) -> bool:
+        self.path = self._path_entry.get()
+        try:
+            self.max_attempts.set(int(self._attempts_entry.get()))
+        except ValueError:
+            messagebox.showerror("오류", "시도 횟수는 정수여야 합니다")
+            return False
+        return True
 
-        def ok():
-            self.path = path_entry.get()
-            try:
-                self.max_attempts.set(int(attempts_entry.get()))
-            except ValueError:
-                messagebox.showerror("오류", "시도 횟수는 정수여야 합니다")
-                return
-            result["ok"] = True
-            top.destroy()
-
-        def cancel():
-            top.destroy()
-
-        tk.Button(top, text="확인", command=ok).grid(row=4, column=1, padx=5, pady=5)
-        tk.Button(top, text="취소", command=cancel).grid(row=4, column=2, padx=5, pady=5)
-        top.grab_set()
-        parent.wait_window(top)
-        return result["ok"]
 
 
 class MouseStep(MacroStep):
@@ -218,78 +182,61 @@ class MouseStep(MacroStep):
             f"@({self.x.get()}, {self.y.get()})"
         )
 
-    def edit(self, parent: tk.Tk):
-        top = tk.Toplevel(parent)
-        top.title("마우스 단계")
+    def build_editor(self, parent: tk.Widget):
+        tk.Label(parent, text="X:").grid(row=0, column=0, sticky="w", padx=5, pady=5)
+        self._x_entry = tk.Entry(parent, width=6)
+        self._x_entry.insert(0, str(self.x.get()))
+        self._x_entry.grid(row=0, column=1, padx=5, pady=5)
 
-        tk.Label(top, text="X:").grid(row=0, column=0, sticky="w", padx=5, pady=5)
-        x_entry = tk.Entry(top, width=6)
-        x_entry.insert(0, str(self.x.get()))
-        x_entry.grid(row=0, column=1, padx=5, pady=5)
-
-        tk.Label(top, text="Y:").grid(row=0, column=2, sticky="w", padx=5, pady=5)
-        y_entry = tk.Entry(top, width=6)
-        y_entry.insert(0, str(self.y.get()))
-        y_entry.grid(row=0, column=3, padx=5, pady=5)
+        tk.Label(parent, text="Y:").grid(row=0, column=2, sticky="w", padx=5, pady=5)
+        self._y_entry = tk.Entry(parent, width=6)
+        self._y_entry.insert(0, str(self.y.get()))
+        self._y_entry.grid(row=0, column=3, padx=5, pady=5)
 
         def capture(event=None):
             if pyautogui:
                 pos = pyautogui.position()
-                x_entry.delete(0, tk.END)
-                x_entry.insert(0, str(pos.x))
-                y_entry.delete(0, tk.END)
-                y_entry.insert(0, str(pos.y))
+                self._x_entry.delete(0, tk.END)
+                self._x_entry.insert(0, str(pos.x))
+                self._y_entry.delete(0, tk.END)
+                self._y_entry.insert(0, str(pos.y))
             else:
                 messagebox.showinfo("정보", "pyautogui를 사용할 수 없습니다")
 
-        top.bind("<F10>", capture)
+        parent.bind("<F10>", capture)
 
-        tk.Label(top, text="버튼:").grid(row=1, column=0, sticky="w", padx=5, pady=5)
+        tk.Label(parent, text="버튼:").grid(row=1, column=0, sticky="w", padx=5, pady=5)
         buttons = {"왼쪽": "left", "오른쪽": "right", "가운데": "middle"}
-        button_combo = ttk.Combobox(top, values=list(buttons.keys()), state="readonly")
-        current_button = next(k for k, v in buttons.items() if v == self.button.get())
-        button_combo.set(current_button)
-        button_combo.grid(row=1, column=1, padx=5, pady=5)
+        self._button_combo = ttk.Combobox(parent, values=list(buttons.keys()), state="readonly")
+        self._button_combo.set(next(k for k, v in buttons.items() if v == self.button.get()))
+        self._button_combo.grid(row=1, column=1, padx=5, pady=5)
 
-        tk.Label(top, text="동작:").grid(row=1, column=2, sticky="w", padx=5, pady=5)
+        tk.Label(parent, text="동작:").grid(row=1, column=2, sticky="w", padx=5, pady=5)
         actions = {"클릭": "click", "누르기": "press", "떼기": "release"}
-        action_combo = ttk.Combobox(top, values=list(actions.keys()), state="readonly")
-        current_action = next(k for k, v in actions.items() if v == self.action.get())
-        action_combo.set(current_action)
-        action_combo.grid(row=1, column=3, padx=5, pady=5)
+        self._action_combo = ttk.Combobox(parent, values=list(actions.keys()), state="readonly")
+        self._action_combo.set(next(k for k, v in actions.items() if v == self.action.get()))
+        self._action_combo.grid(row=1, column=3, padx=5, pady=5)
 
-        double_chk = tk.Checkbutton(top, text="더블", variable=self.double)
-        double_chk.grid(row=2, column=0, sticky="w", padx=5, pady=5)
+        tk.Checkbutton(parent, text="더블", variable=self.double).grid(row=2, column=0, sticky="w", padx=5, pady=5)
 
-        tk.Label(top, text="간격(초):").grid(row=2, column=1, sticky="w", padx=5, pady=5)
-        interval_entry = tk.Entry(top, width=6)
-        interval_entry.insert(0, str(self.interval.get()))
-        interval_entry.grid(row=2, column=2, padx=5, pady=5)
-        result = {"ok": False}
+        tk.Label(parent, text="간격(초):").grid(row=2, column=1, sticky="w", padx=5, pady=5)
+        self._interval_entry = tk.Entry(parent, width=6)
+        self._interval_entry.insert(0, str(self.interval.get()))
+        self._interval_entry.grid(row=2, column=2, padx=5, pady=5)
 
-        def ok():
-            try:
-                self.x.set(int(x_entry.get()))
-                self.y.set(int(y_entry.get()))
-                self.interval.set(float(interval_entry.get()))
-            except ValueError:
-                messagebox.showerror("오류", "잘못된 숫자 값")
-                return
-            self.button.set(buttons[button_combo.get()])
-            self.action.set(actions[action_combo.get()])
-            top.unbind("<F10>")
-            result["ok"] = True
-            top.destroy()
-
-        def cancel():
-            top.unbind("<F10>")
-            top.destroy()
-
-        tk.Button(top, text="확인", command=ok).grid(row=3, column=1, padx=5, pady=5)
-        tk.Button(top, text="취소", command=cancel).grid(row=3, column=2, padx=5, pady=5)
-        top.grab_set()
-        parent.wait_window(top)
-        return result["ok"]
+    def apply_editor(self) -> bool:
+        buttons = {"왼쪽": "left", "오른쪽": "right", "가운데": "middle"}
+        actions = {"클릭": "click", "누르기": "press", "떼기": "release"}
+        try:
+            self.x.set(int(self._x_entry.get()))
+            self.y.set(int(self._y_entry.get()))
+            self.interval.set(float(self._interval_entry.get()))
+        except ValueError:
+            messagebox.showerror("오류", "잘못된 숫자 값")
+            return False
+        self.button.set(buttons[self._button_combo.get()])
+        self.action.set(actions[self._action_combo.get()])
+        return True
 
 
 class KeyboardStep(MacroStep):
@@ -306,56 +253,42 @@ class KeyboardStep(MacroStep):
         }
         return f"키보드 {act_names.get(self.action.get(), self.action.get())} {self.key.get()}"
 
-    def edit(self, parent: tk.Tk):
-        top = tk.Toplevel(parent)
-        top.title("키보드 단계")
-
-        tk.Label(top, text="키:").grid(row=0, column=0, sticky="w", padx=5, pady=5)
-        key_entry = tk.Entry(top, width=10)
-        key_entry.insert(0, self.key.get())
-        key_entry.grid(row=0, column=1, padx=5, pady=5)
+    def build_editor(self, parent: tk.Widget):
+        tk.Label(parent, text="키:").grid(row=0, column=0, sticky="w", padx=5, pady=5)
+        self._key_entry = tk.Entry(parent, width=10)
+        self._key_entry.insert(0, self.key.get())
+        self._key_entry.grid(row=0, column=1, padx=5, pady=5)
 
         capturing = tk.BooleanVar(value=False)
 
         def capture_key(event):
             if capturing.get():
                 self.key.set(event.keysym)
-                key_entry.delete(0, tk.END)
-                key_entry.insert(0, self.key.get())
+                self._key_entry.delete(0, tk.END)
+                self._key_entry.insert(0, self.key.get())
                 capturing.set(False)
-                top.unbind("<Key>")
+                parent.unbind("<Key>")
 
         def start_capture():
             capturing.set(True)
-            top.bind("<Key>", capture_key)
+            parent.bind("<Key>", capture_key)
 
-        tk.Button(top, text="입력", command=start_capture).grid(row=0, column=2, padx=5, pady=5)
+        tk.Button(parent, text="입력", command=start_capture).grid(row=0, column=2, padx=5, pady=5)
 
-        tk.Label(top, text="동작:").grid(row=1, column=0, sticky="w", padx=5, pady=5)
+        tk.Label(parent, text="동작:").grid(row=1, column=0, sticky="w", padx=5, pady=5)
         actions = [
             ("누르고 떼기", "press_release"),
             ("누르기", "press"),
             ("떼기", "release"),
         ]
         for i, (label, value) in enumerate(actions):
-            tk.Radiobutton(top, text=label, variable=self.action, value=value).grid(
+            tk.Radiobutton(parent, text=label, variable=self.action, value=value).grid(
                 row=1, column=1 + i, sticky="w", padx=5, pady=5
             )
-        result = {"ok": False}
 
-        def ok():
-            self.key.set(key_entry.get())
-            result["ok"] = True
-            top.destroy()
-
-        def cancel():
-            top.destroy()
-
-        tk.Button(top, text="확인", command=ok).grid(row=2, column=1, padx=5, pady=5)
-        tk.Button(top, text="취소", command=cancel).grid(row=2, column=2, padx=5, pady=5)
-        top.grab_set()
-        parent.wait_window(top)
-        return result["ok"]
+    def apply_editor(self) -> bool:
+        self.key.set(self._key_entry.get())
+        return True
 
 
 class DelayStep(MacroStep):
@@ -366,38 +299,23 @@ class DelayStep(MacroStep):
     def summary(self) -> str:
         return f"지연 {self.duration.get():.3f}초"
 
-    def edit(self, parent: tk.Tk):
-        top = tk.Toplevel(parent)
-        top.title("지연 단계")
+    def build_editor(self, parent: tk.Widget):
+        tk.Label(parent, text="초:").grid(row=0, column=0, sticky="w", padx=5, pady=5)
+        self._entry = tk.Entry(parent, width=10)
+        self._entry.insert(0, str(self.duration.get()))
+        self._entry.grid(row=0, column=1, padx=5, pady=5)
 
-        tk.Label(top, text="초:").grid(row=0, column=0, sticky="w", padx=5, pady=5)
-        entry = tk.Entry(top, width=10)
-        entry.insert(0, str(self.duration.get()))
-        entry.grid(row=0, column=1, padx=5, pady=5)
-
-        result = {"ok": False}
-
-        def ok():
-            try:
-                val = float(entry.get())
-            except ValueError:
-                messagebox.showerror("오류", "잘못된 숫자")
-                return
-            if val < 0.001:
-                messagebox.showerror("오류", "0.001 이상이어야 합니다")
-                return
-            self.duration.set(val)
-            result["ok"] = True
-            top.destroy()
-
-        def cancel():
-            top.destroy()
-
-        tk.Button(top, text="확인", command=ok).grid(row=1, column=1, padx=5, pady=5)
-        tk.Button(top, text="취소", command=cancel).grid(row=1, column=2, padx=5, pady=5)
-        top.grab_set()
-        parent.wait_window(top)
-        return result["ok"]
+    def apply_editor(self) -> bool:
+        try:
+            val = float(self._entry.get())
+        except ValueError:
+            messagebox.showerror("오류", "잘못된 숫자")
+            return False
+        if val < 0.001:
+            messagebox.showerror("오류", "0.001 이상이어야 합니다")
+            return False
+        self.duration.set(val)
+        return True
 
 
 class TextStep(MacroStep):
@@ -409,30 +327,15 @@ class TextStep(MacroStep):
         txt = self.text.get()
         return f"텍스트: {txt[:10]}" + ("..." if len(txt) > 10 else "")
 
-    def edit(self, parent: tk.Tk):
-        top = tk.Toplevel(parent)
-        top.title("텍스트 단계")
+    def build_editor(self, parent: tk.Widget):
+        tk.Label(parent, text="텍스트:").grid(row=0, column=0, sticky="w", padx=5, pady=5)
+        self._entry = tk.Entry(parent, width=40)
+        self._entry.insert(0, self.text.get())
+        self._entry.grid(row=0, column=1, padx=5, pady=5)
 
-        tk.Label(top, text="텍스트:").grid(row=0, column=0, sticky="w", padx=5, pady=5)
-        entry = tk.Entry(top, width=40)
-        entry.insert(0, self.text.get())
-        entry.grid(row=0, column=1, padx=5, pady=5)
-
-        result = {"ok": False}
-
-        def ok():
-            self.text.set(entry.get())
-            result["ok"] = True
-            top.destroy()
-
-        def cancel():
-            top.destroy()
-
-        tk.Button(top, text="확인", command=ok).grid(row=1, column=1, padx=5, pady=5)
-        tk.Button(top, text="취소", command=cancel).grid(row=1, column=2, padx=5, pady=5)
-        top.grab_set()
-        parent.wait_window(top)
-        return result["ok"]
+    def apply_editor(self) -> bool:
+        self.text.set(self._entry.get())
+        return True
 
 
 class RepeatStep(MacroStep):
@@ -443,35 +346,19 @@ class RepeatStep(MacroStep):
     def summary(self) -> str:
         return f"반복 {self.count.get()}회"
 
-    def edit(self, parent: tk.Tk):
-        top = tk.Toplevel(parent)
-        top.title("반복 단계")
+    def build_editor(self, parent: tk.Widget):
+        tk.Label(parent, text="횟수:").grid(row=0, column=0, sticky="w", padx=5, pady=5)
+        self._entry = tk.Entry(parent, width=5)
+        self._entry.insert(0, str(self.count.get()))
+        self._entry.grid(row=0, column=1, padx=5, pady=5)
 
-        tk.Label(top, text="횟수:").grid(row=0, column=0, sticky="w", padx=5, pady=5)
-        entry = tk.Entry(top, width=5)
-        entry.insert(0, str(self.count.get()))
-        entry.grid(row=0, column=1, padx=5, pady=5)
-
-        result = {"ok": False}
-
-        def ok():
-            try:
-                val = int(entry.get())
-            except ValueError:
-                messagebox.showerror("오류", "잘못된 숫자")
-                return
-            self.count.set(val)
-            result["ok"] = True
-            top.destroy()
-
-        def cancel():
-            top.destroy()
-
-        tk.Button(top, text="확인", command=ok).grid(row=1, column=1, padx=5, pady=5)
-        tk.Button(top, text="취소", command=cancel).grid(row=1, column=2, padx=5, pady=5)
-        top.grab_set()
-        parent.wait_window(top)
-        return result["ok"]
+    def apply_editor(self) -> bool:
+        try:
+            self.count.set(int(self._entry.get()))
+        except ValueError:
+            messagebox.showerror("오류", "잘못된 숫자")
+            return False
+        return True
 
 
 class MacroApp:
@@ -479,19 +366,22 @@ class MacroApp:
         self.root = root
         self.steps: list[MacroStep] = []
 
-        left = tk.Frame(root)
-        left.pack(side=tk.LEFT, fill=tk.Y, padx=5, pady=5)
+        self.editor = tk.Frame(root, width=250, bd=1, relief=tk.SUNKEN)
+        self.editor.pack(side=tk.RIGHT, fill=tk.Y, padx=5, pady=5)
+        self.editor.pack_propagate(False)
 
-        tk.Button(left, text="이미지 추가", command=self.add_image).pack(fill=tk.X, pady=5)
-        tk.Button(left, text="마우스 추가", command=self.add_mouse).pack(fill=tk.X, pady=5)
-        tk.Button(left, text="키보드 추가", command=self.add_keyboard).pack(fill=tk.X, pady=5)
-        tk.Button(left, text="지연 추가", command=self.add_delay).pack(fill=tk.X, pady=5)
-        tk.Button(left, text="텍스트 추가", command=self.add_text).pack(fill=tk.X, pady=5)
-        tk.Button(left, text="반복 추가", command=self.add_repeat).pack(fill=tk.X, pady=5)
-        tk.Button(left, text="삭제", command=self.delete_selected).pack(fill=tk.X, pady=5)
+        buttons = tk.Frame(root)
+        buttons.pack(side=tk.RIGHT, fill=tk.Y, padx=5, pady=5)
+        tk.Button(buttons, text="이미지 추가", command=self.add_image).pack(fill=tk.X, pady=5)
+        tk.Button(buttons, text="마우스 추가", command=self.add_mouse).pack(fill=tk.X, pady=5)
+        tk.Button(buttons, text="키보드 추가", command=self.add_keyboard).pack(fill=tk.X, pady=5)
+        tk.Button(buttons, text="지연 추가", command=self.add_delay).pack(fill=tk.X, pady=5)
+        tk.Button(buttons, text="텍스트 추가", command=self.add_text).pack(fill=tk.X, pady=5)
+        tk.Button(buttons, text="반복 추가", command=self.add_repeat).pack(fill=tk.X, pady=5)
+        tk.Button(buttons, text="삭제", command=self.delete_selected).pack(fill=tk.X, pady=5)
 
         self.listbox = tk.Listbox(root)
-        self.listbox.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True, padx=5, pady=5)
+        self.listbox.pack(side=tk.LEFT, fill=tk.BOTH, expand=True, padx=5, pady=5)
 
         self.listbox.bind('<Double-Button-1>', self.edit_selected)
         self.listbox.bind('<ButtonPress-1>', self.start_drag)
@@ -499,10 +389,46 @@ class MacroApp:
         self.listbox.bind('<Delete>', self.delete_selected)
         self.drag_index = None
 
+        self.editing_step: MacroStep | None = None
+        self.editing_index: int | None = None
+
+    def open_editor(self, step: MacroStep, index: int | None):
+        if self.editing_step is not None:
+            return
+        self.editing_step = step
+        self.editing_index = index
+        for w in self.editor.winfo_children():
+            w.destroy()
+        form = tk.Frame(self.editor)
+        form.pack(fill=tk.BOTH, expand=True)
+        step.build_editor(form)
+        btns = tk.Frame(self.editor)
+        btns.pack(fill=tk.X, pady=5)
+        tk.Button(btns, text="확인", command=self.confirm_edit).pack(side=tk.LEFT, padx=5)
+        tk.Button(btns, text="취소", command=self.cancel_edit).pack(side=tk.LEFT, padx=5)
+
+    def confirm_edit(self):
+        if not self.editing_step or not self.editing_step.apply_editor():
+            return
+        if self.editing_index is None:
+            self.steps.append(self.editing_step)
+            self.listbox.insert(tk.END, self.editing_step.summary())
+        else:
+            self.listbox.delete(self.editing_index)
+            self.listbox.insert(self.editing_index, self.editing_step.summary())
+        self.close_editor()
+
+    def cancel_edit(self):
+        self.close_editor()
+
+    def close_editor(self):
+        for w in self.editor.winfo_children():
+            w.destroy()
+        self.editing_step = None
+        self.editing_index = None
+
     def add_step(self, step: MacroStep):
-        if step.edit(self.root):
-            self.steps.append(step)
-            self.listbox.insert(tk.END, step.summary())
+        self.open_editor(step, None)
 
     def add_image(self):
         self.add_step(ImageStep())
@@ -526,19 +452,23 @@ class MacroApp:
         idx = self.listbox.curselection()
         if not idx:
             return
+        if event is not None and self.editing_step is not None:
+            return
         i = idx[0]
+        if self.editing_step is not None and i == self.editing_index:
+            messagebox.showinfo("정보", "편집중인 블록은 삭제할 수 없습니다.")
+            return
         del self.steps[i]
         self.listbox.delete(i)
+        if self.editing_step is not None and self.editing_index is not None and i < self.editing_index:
+            self.editing_index -= 1
 
     def edit_selected(self, event=None):
         idx = self.listbox.curselection()
         if not idx:
             return
         i = idx[0]
-        step = self.steps[i]
-        if step.edit(self.root):
-            self.listbox.delete(i)
-            self.listbox.insert(i, step.summary())
+        self.open_editor(self.steps[i], i)
 
     def start_drag(self, event):
         self.drag_index = self.listbox.nearest(event.y)
@@ -552,13 +482,20 @@ class MacroApp:
         self.listbox.delete(self.drag_index)
         self.steps.insert(i, item)
         self.listbox.insert(i, text)
+        if self.editing_index is not None:
+            if self.drag_index == self.editing_index:
+                self.editing_index = i
+            elif self.drag_index < self.editing_index <= i:
+                self.editing_index -= 1
+            elif i <= self.editing_index < self.drag_index:
+                self.editing_index += 1
         self.drag_index = i
 
 
 def main():
     root = tk.Tk()
     root.title("이미지 매크로 빌더")
-    root.geometry("800x600")
+    root.geometry("600x400")
     app = MacroApp(root)
     root.mainloop()
 


### PR DESCRIPTION
## Summary
- Move macro control buttons to the right and add a dedicated editor panel
- Switch step editing to inline forms with confirm/cancel controls
- Prevent deleting the step being edited and shrink window size

## Testing
- `python -m py_compile imagemacro.py`

------
https://chatgpt.com/codex/tasks/task_e_68b191133e408332bda40fed29837a00