### PR TITLE
Fix image capture overlay destruction causing Tkinter error

### DIFF
--- a/imagemacro.py
+++ b/imagemacro.py
@@ -104,11 +104,11 @@ class ImageStep(MacroStep):
                     canvas.coords(rect["id"], start["x"], start["y"], event.x, event.y)
 
             def on_release(event):
-                overlay.destroy()
                 x1 = overlay.winfo_rootx() + start["x"]
                 y1 = overlay.winfo_rooty() + start["y"]
                 x2 = overlay.winfo_rootx() + event.x
                 y2 = overlay.winfo_rooty() + event.y
+                overlay.destroy()
                 region = (min(x1, x2), min(y1, y2), abs(x2 - x1), abs(y2 - y1))
                 img = pyautogui.screenshot(region=region)
                 fd, tmp = tempfile.mkstemp(suffix=".png")


### PR DESCRIPTION
## Summary
- avoid TclError by destroying overlay after obtaining root coordinates

## Testing
- `python -m py_compile imagemacro.py`
- `python imagemacro.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f52d52948332a79912f8af8dd8f8